### PR TITLE
Fix panic when removing parenthesis from if directives

### DIFF
--- a/parse_test.go
+++ b/parse_test.go
@@ -454,6 +454,69 @@ var parseFixtures = []parseFixture{
 			},
 		},
 	}},
+	parseFixture{"simple-with-if", "-ignore-directives-1", ParseOptions{IgnoreDirectives: []string{"listen", "server_name"}}, Payload{
+		Status: "ok",
+		Errors: []PayloadError{},
+		Config: []Config{
+			Config{
+				File:   filepath.Join("testdata", "simple-with-if", "nginx.conf"),
+				Status: "ok",
+				Errors: []ConfigError{},
+				Parsed: []Directive{
+					Directive{
+						Directive: "events",
+						Args:      []string{},
+						Line:      1,
+						Block: &[]Directive{
+							Directive{
+								Directive: "worker_connections",
+								Args:      []string{"1024"},
+								Line:      2,
+							},
+						},
+					},
+					Directive{
+						Directive: "http",
+						Args:      []string{},
+						Line:      5,
+						Block: &[]Directive{
+							Directive{
+								Directive: "server",
+								Args:      []string{},
+								Line:      6,
+								Block: &[]Directive{
+									Directive{
+										Directive: "location",
+										Args:      []string{"/"},
+										Line:      10,
+										Block: &[]Directive{
+											Directive{
+												Directive: "if",
+												Args:      []string{"$scheme", "=", "http"},
+												Line:      11,
+												Block: &[]Directive{
+													Directive{
+														Directive: "return",
+														Args:      []string{"200", "foo bar"},
+														Line:      12,
+													},
+												},
+											},
+											Directive{
+												Directive: "return",
+												Args:      []string{"200", "foo bar baz"},
+												Line:      14,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}},
 	parseFixture{"simple", "-ignore-directives-2", ParseOptions{IgnoreDirectives: []string{"events", "server"}}, Payload{
 		Status: "ok",
 		Errors: []PayloadError{},

--- a/testdata/simple-with-if/nginx.conf
+++ b/testdata/simple-with-if/nginx.conf
@@ -1,0 +1,17 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    server {
+        listen       127.0.0.1:8080;
+        server_name  default_server;
+
+        location / {
+            if ( $scheme = "http" ) {
+                return 200 "foo bar";
+            }
+            return 200 "foo bar baz";
+        }
+    }
+}

--- a/util.go
+++ b/util.go
@@ -50,6 +50,7 @@ func prepareIfArgs(d Directive) Directive {
 		d.Args[e] = strings.TrimRightFunc(strings.TrimSuffix(d.Args[e], ")"), unicode.IsSpace)
 		if len(d.Args[0]) == 0 {
 			d.Args = d.Args[1:]
+			e -= 1
 		}
 		if len(d.Args[e]) == 0 {
 			d.Args = d.Args[:e]


### PR DESCRIPTION
Fixes https://github.com/aluttik/go-crossplane/issues/12

The problem where was that `e` was pointing to the last position of the `d.Args` slice, but when an `(` parenthesis was removed from the slice, `e` was not being updated with the new last position of the slice. This PR fixes it.

Added a new test along with this change.